### PR TITLE
Refactor WebDriver command instantiation for isolation

### DIFF
--- a/src/G4.WebDriver.Remote.Uia/UiaDriver.cs
+++ b/src/G4.WebDriver.Remote.Uia/UiaDriver.cs
@@ -234,8 +234,8 @@ namespace G4.WebDriver.Remote.Uia
         /// <inheritdoc />
         public void SendInputs(int repeat, params string[] codes)
         {
-            // Prepare the WebDriver command for sending scan codes to the server for input simulation
-            var command = Invoker.Commands["SendUser32Inputs"];
+            // Create an invocation-owned scan-code command so repeated input requests cannot exchange payload state.
+            var command = Invoker.NewCommand(commandName: "SendUser32Inputs");
             command.Session = Session.OpaqueKey;
             command.Data = new ScanCodesInputModel
             {
@@ -277,8 +277,8 @@ namespace G4.WebDriver.Remote.Uia
         /// <inheritdoc />
         public void SendKeys(int repeat, string text)
         {
-            // Prepare the WebDriver command for sending text input to the server for input simulation
-            var command = Invoker.Commands["SendUser32Keys"];
+            // Create an invocation-owned text command so repeated input requests cannot exchange payload state.
+            var command = Invoker.NewCommand(commandName: "SendUser32Keys");
             command.Session = Session.OpaqueKey;
             command.Data = new TextInputModel
             {

--- a/src/G4.WebDriver.Remote.Uia/UiaElement.cs
+++ b/src/G4.WebDriver.Remote.Uia/UiaElement.cs
@@ -1,4 +1,5 @@
-﻿using G4.WebDriver.Models;
+﻿using G4.WebDriver.Extensions;
+using G4.WebDriver.Models;
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -43,8 +44,8 @@ namespace G4.WebDriver.Remote.Uia
         /// <inheritdoc />
         new public string GetAttribute(string attributeName)
         {
-            // Prepare the WebDriver command for retrieving the value of an attribute for the current WebElement
-            var command = _invoker.Commands["GetUser32Attribute"];
+            // Create an invocation-owned attribute command so changing route values cannot alter the registered template.
+            var command = _invoker.NewCommand(commandName: "GetUser32Attribute");
             command.Session = _session.OpaqueKey;
             command.Element = Id;
 
@@ -70,8 +71,8 @@ namespace G4.WebDriver.Remote.Uia
         /// <inheritdoc />
         public void MoveToElement(MousePositionInputModel positionData)
         {
-            // Prepare the WebDriver command for moving the mouse pointer to the current WebElement
-            var command = _invoker.Commands["MoveUser32MouseToElement"];
+            // Create an invocation-owned movement command so this element and payload remain isolated from later requests.
+            var command = _invoker.NewCommand(commandName: "MoveUser32MouseToElement");
             command.Session = _session.OpaqueKey;
             command.Element = Id;
             command.Data = positionData;
@@ -83,8 +84,8 @@ namespace G4.WebDriver.Remote.Uia
         /// <inheritdoc />
         public void SendClick()
         {
-            // Prepare the WebDriver command for sending a native click command to the current WebElement
-            var command = _invoker.Commands["SendUser32ClickToElement"];
+            // Create an invocation-owned click command so this element identifier never changes the registered template.
+            var command = _invoker.NewCommand(commandName: "SendUser32ClickToElement");
             command.Session = _session.OpaqueKey;
             command.Element = Id;
 
@@ -95,8 +96,8 @@ namespace G4.WebDriver.Remote.Uia
         /// <inheritdoc />
         public void SendDoubleClick()
         {
-            // Prepare the WebDriver command for sending a native double-click command to the current WebElement
-            var command = _invoker.Commands["SendUser32DoubleClickToElement"];
+            // Create an invocation-owned double-click command so concurrent element requests retain independent state.
+            var command = _invoker.NewCommand(commandName: "SendUser32DoubleClickToElement");
             command.Session = _session.OpaqueKey;
             command.Element = Id;
 
@@ -107,8 +108,8 @@ namespace G4.WebDriver.Remote.Uia
         /// <inheritdoc />
         public void SetFocus()
         {
-            // Prepare the WebDriver command for setting focus on the current WebElement
-            var command = _invoker.Commands["SetUser32Focus"];
+            // Create an invocation-owned focus command so sequential elements resolve to their own endpoint routes.
+            var command = _invoker.NewCommand(commandName: "SetUser32Focus");
             command.Session = _session.OpaqueKey;
             command.Element = Id;
 

--- a/src/G4.WebDriver.Tests/UiaDriverTests.cs
+++ b/src/G4.WebDriver.Tests/UiaDriverTests.cs
@@ -1,9 +1,18 @@
-﻿using G4.WebDriver.Models;
+﻿using G4.WebDriver.Extensions;
+using G4.WebDriver.Models;
+using G4.WebDriver.Remote;
 using G4.WebDriver.Remote.Uia;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using System;
+using System.Collections.Concurrent;
 using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace G4.WebDriver.Tests
 {
@@ -12,72 +21,304 @@ namespace G4.WebDriver.Tests
     [TestCategory("WindowsAppTest")]
     public class UiaDriverTests : TestBase<UiaDriver>
     {
+        [TestMethod(DisplayName = "Verify that repeated UIA attribute commands resolve each attribute from an isolated route template.")]
+        [TestCategory("UnitTest")]
+        public void GetAttributeSequentialNamesTest()
+        {
+            // Arrange: record local requests so attribute route expansion is verified without a live UIA server.
+            var messageHandler = new RecordingHttpMessageHandler();
+            using var httpClient = new HttpClient(handler: messageHandler, disposeHandler: true);
+            var invoker = NewCommandInvoker(httpClient);
+            using var driver = NewRemoteDriver(invoker);
+            var element = new UiaElement(driver, id: "right-id");
+
+            // Act: request two attributes through one element and one command registry.
+            var name = element.GetAttribute("Name");
+            var automationId = element.GetAttribute("AutomationId");
+
+            // Assert: retain both successful responses so route verification covers completed command invocations.
+            Assert.AreEqual("captured", name);
+            Assert.AreEqual("captured", automationId);
+
+            // Assert: preserve each changing attribute in its own endpoint instead of reusing the first expanded route.
+            var requestUris = messageHandler.GetRequestUris();
+            Assert.HasCount(2, requestUris);
+            Assert.AreEqual("/session/session-id/element/right-id/attribute/Name", requestUris[0].AbsolutePath);
+            Assert.AreEqual("/session/session-id/element/right-id/attribute/AutomationId", requestUris[1].AbsolutePath);
+
+            // Assert: keep the registered route reusable after every invocation.
+            var template = invoker.Commands["GetUser32Attribute"];
+            Assert.AreEqual(
+                "/session/$[session]/element/$[element]/attribute/$[attributeName]",
+                template.Route);
+        }
+
+        [TestMethod(DisplayName = "Verify that invoking a UIA command preserves the caller-owned route and registered template.")]
+        [TestCategory("UnitTest")]
+        public void InvokeCommandPreservesCallerRouteTest()
+        {
+            // Arrange: create one invocation-owned focus command whose route still contains both placeholders.
+            var messageHandler = new RecordingHttpMessageHandler();
+            using var httpClient = new HttpClient(handler: messageHandler, disposeHandler: true);
+            var invoker = NewCommandInvoker(httpClient);
+            var command = invoker.NewCommand(commandName: "SetUser32Focus");
+            command.Element = "right-id";
+
+            // Act: send the command through the production invoker where route expansion occurs.
+            invoker.Invoke(command);
+
+            // Assert: send the resolved right-element endpoint while retaining the caller-owned route.
+            var requestUris = messageHandler.GetRequestUris();
+            Assert.HasCount(1, requestUris);
+            Assert.AreEqual(
+                "/session/session-id/user32/element/right-id/focus",
+                requestUris[0].AbsolutePath);
+
+            // Assert: keep both caller and registry routes reusable after transport completes.
+            const string ExpectedRoute = "/session/$[session]/user32/element/$[element]/focus";
+            Assert.AreEqual(ExpectedRoute, command.Route);
+            Assert.AreEqual(ExpectedRoute, invoker.Commands["SetUser32Focus"].Route);
+        }
+
         [TestMethod(DisplayName = "Verify that a new application driver can be instantiated and perform UI interactions correctly.")]
         public void NewApplicationDriverTest()
         {
-            // Retrieve the local Grid endpoint path from the test context properties
+            // Arrange: redirect the test driver to the UIA binaries used by the Windows application fixture.
             var binariesPath = $"{TestContext.Properties["Grid.Endpoint"]}";
-
-            // Update the local Grid endpoint property with the path to the UiaDriverServer binaries
             TestContext.Properties["Grid.Endpoint"] = Path.Combine(binariesPath, "UiaDriverServer");
 
-            // Configure UiaOptions with the path to the application executable
+            // Arrange: configure the application and stable automation identifiers needed for the interaction.
             var options = new UiaOptions
             {
                 App = "E:\\Binaries\\Automation\\SimpleWpfTestApp.exe"
             };
-
-            // Define locators for UI elements using their automation IDs
             var textbox = By.Xpath("//Edit[@AutomationId='InputTextBoxAutomationId']");
             var button = By.Xpath("//Button[@AutomationId='SubmitButtonAutomationId']");
             var label = By.Xpath("//Text[@AutomationId='OutputLabelAutomationId']");
 
-            // Invoke the driver with specified options and an empty URL, passing in an action to interact with the UI elements
+            // Act: exercise text entry and submission through the complete UIA driver lifecycle.
             Invoke(
                 TestContext,
                 options,
                 url: string.Empty,
                 action: driver =>
                 {
-                    // Enter text into the input text box
+                    // Act: enter and submit text before querying the resulting label state.
                     driver.FindElement(textbox).SendKeys("Foo");
-
-                    // Click the submit button
                     driver.FindElement(button).Click();
 
-                    // Retrieve the text from the output label
+                    // Assert: verify the application received the input and published the expected label.
                     var actual = driver.FindElement(label).GetAttribute("Name");
-
-                    // Verify that the output label displays the correct text after the button click
                     Assert.AreEqual("You entered: Foo", actual, $"Output label text mismatch. Expected 'You entered: Foo' but got '{actual}'.");
                 }
             );
         }
 
+        [TestMethod(DisplayName = "Verify that new commands own independent request state while the registered template remains unchanged.")]
+        [TestCategory("UnitTest")]
+        public void NewCommandIndependentInstancesTest()
+        {
+            // Arrange: register UIA command templates in an invoker that performs no network request for this copy test.
+            var messageHandler = new RecordingHttpMessageHandler();
+            using var httpClient = new HttpClient(handler: messageHandler, disposeHandler: true);
+            var invoker = NewCommandInvoker(httpClient);
+
+            // Act: create two commands from one template and mutate only the first command.
+            var leftCommand = invoker.NewCommand(commandName: "SetUser32Focus");
+            var rightCommand = invoker.NewCommand(commandName: "SetUser32Focus");
+            leftCommand.Element = "left-id";
+            leftCommand.Route = leftCommand.Route
+                .Replace("$[session]", leftCommand.Session)
+                .Replace("$[element]", leftCommand.Element);
+
+            // Assert: expose distinct instances so request state cannot leak between invocations.
+            Assert.AreNotSame(leftCommand, rightCommand);
+            Assert.AreNotSame(leftCommand, invoker.Commands["SetUser32Focus"]);
+            Assert.AreNotSame(rightCommand, invoker.Commands["SetUser32Focus"]);
+            Assert.IsNull(rightCommand.Element);
+
+            // Assert: retain placeholders in both the untouched command and registered template.
+            const string ExpectedRoute = "/session/$[session]/user32/element/$[element]/focus";
+            Assert.AreEqual(ExpectedRoute, rightCommand.Route);
+            Assert.AreEqual(ExpectedRoute, invoker.Commands["SetUser32Focus"].Route);
+        }
+
         [TestMethod(DisplayName = "Verify that a new UiaDriver can be instantiated and is not ready by default.")]
         public void NewDesktopDriverTest()
         {
-            // Retrieve the local Grid endpoint path from the test context properties
+            // Arrange: redirect the test driver to the UIA binaries used by the desktop fixture.
             var binariesPath = $"{TestContext.Properties["Grid.Endpoint"]}";
-
-            // Update the local Grid endpoint property with the path to the UiaDriverServer binaries
             TestContext.Properties["Grid.Endpoint"] = Path.Combine(binariesPath, "UiaDriverServer");
 
-            // Invoke the driver with default options and an empty URL, passing in an action to validate the driver state
+            // Act: instantiate the desktop driver through the shared lifecycle without opening an application URL.
             Invoke(
                 TestContext,
                 options: default,
                 url: string.Empty,
                 action: driver =>
                 {
-                    // Verify that the WebDriverService is not ready when the driver is instantiated
-                    // This confirms that only one Windows instance is supported
-                    Assert.IsFalse(driver.Invoker.WebDriverService.Ready, "WebDriverService is reported as ready, but it should be in a not-ready state since only one Windows instance is supported.");
+                    // Assert: retain the single-Windows-instance service state and a valid driver instance.
+                    Assert.IsFalse(
+                        driver.Invoker.WebDriverService.Ready,
+                        "WebDriverService is ready even though UIA supports only one Windows instance.");
 
-                    // Verify that the driver object is not null, confirming successful instantiation
                     Assert.IsNotNull(driver, "Driver instance is null. Expected a valid driver instance to be created.");
                 }
             );
+        }
+
+        [TestMethod(DisplayName = "Verify that parallel UIA focus commands retain their own element routes.")]
+        [TestCategory("UnitTest")]
+        public async Task SetFocusParallelElementsTestAsync()
+        {
+            // Arrange: share one invoker across two UIA elements so concurrent command ownership is exercised directly.
+            var messageHandler = new RecordingHttpMessageHandler();
+            using var httpClient = new HttpClient(handler: messageHandler, disposeHandler: true);
+            var invoker = NewCommandInvoker(httpClient);
+            using var driver = NewRemoteDriver(invoker);
+            var leftElement = new UiaElement(driver, id: "left-id");
+            var rightElement = new UiaElement(driver, id: "right-id");
+
+            var cancellationToken = new CancellationTokenSource().Token;
+
+            // Act: invoke both focus requests concurrently to expose any shared route or element state.
+            await Task.WhenAll(
+                Task.Run(action: leftElement.SetFocus, cancellationToken),
+                Task.Run(action: rightElement.SetFocus, cancellationToken));
+
+            // Assert: receive exactly one request for each element regardless of completion order.
+            var requestUris = messageHandler.GetRequestUris();
+            var actualPaths = Array.ConvertAll(requestUris, uri => uri.AbsolutePath);
+            var expectedPaths = new[]
+            {
+                "/session/session-id/user32/element/left-id/focus",
+                "/session/session-id/user32/element/right-id/focus"
+            };
+
+            Assert.HasCount(2, requestUris);
+            Assert.AreSequenceEqual(expectedPaths, actualPaths);
+
+            // Assert: retain the registered placeholders after concurrent invocation.
+            Assert.AreEqual(
+                "/session/$[session]/user32/element/$[element]/focus",
+                invoker.Commands["SetUser32Focus"].Route);
+        }
+
+        [TestMethod(DisplayName = "Verify that sequential UIA focus commands target the left and right elements independently.")]
+        [TestCategory("UnitTest")]
+        public void SetFocusSequentialElementsTest()
+        {
+            // Arrange: share one invoker across left and right UIA elements to reproduce the recorded twin-panel flow.
+            var messageHandler = new RecordingHttpMessageHandler();
+            using var httpClient = new HttpClient(handler: messageHandler, disposeHandler: true);
+            var invoker = NewCommandInvoker(httpClient);
+            using var driver = NewRemoteDriver(invoker);
+            var leftElement = new UiaElement(driver, id: "left-id");
+            var rightElement = new UiaElement(driver, id: "right-id");
+
+            // Act: focus the left element first and the right element second through the production UiaElement path.
+            leftElement.SetFocus();
+            rightElement.SetFocus();
+
+            // Assert: preserve each element identifier in the exact request order used by the recording.
+            var requestUris = messageHandler.GetRequestUris();
+            Assert.HasCount(2, requestUris);
+            Assert.AreEqual(
+                "/session/session-id/user32/element/left-id/focus",
+                requestUris[0].AbsolutePath);
+            Assert.AreEqual(
+                "/session/session-id/user32/element/right-id/focus",
+                requestUris[1].AbsolutePath);
+
+            // Assert: retain the registered placeholders for later focus actions.
+            Assert.AreEqual(
+                "/session/$[session]/user32/element/$[element]/focus",
+                invoker.Commands["SetUser32Focus"].Route);
+        }
+
+        // Creates a test-only command invoker whose templates cover the changing UIA routes exercised in this class.
+        // The caller owns the supplied HTTP client, while each command invocation owns its copied request state.
+        private static WebDriverCommandInvoker NewCommandInvoker(HttpClient httpClient)
+        {
+            // Bind transport to an in-memory handler while retaining a complete absolute URI for route assertions.
+            var invoker = new WebDriverCommandInvoker(
+                serverAddress: new Uri(uriString: "http://localhost:4444"),
+                httpClient,
+                timeout: TimeSpan.FromSeconds(5),
+                keepAlive: false)
+            {
+                Session = new SessionIdModel(opaqueKey: "session-id")
+            };
+
+            // Register the element and attribute templates needed to detect placeholder contamination.
+            invoker.AddCommand(
+                commandName: "GetUser32Attribute",
+                command: new WebDriverCommandModel
+                {
+                    Method = HttpMethod.Get,
+                    Route = "/session/$[session]/element/$[element]/attribute/$[attributeName]"
+                });
+            invoker.AddCommand(
+                commandName: "SetUser32Focus",
+                command: new WebDriverCommandModel
+                {
+                    Method = HttpMethod.Get,
+                    Route = "/session/$[session]/user32/element/$[element]/focus"
+                });
+
+            return invoker;
+        }
+
+        // Creates a remote driver with session creation disabled so UiaElement uses the supplied deterministic invoker.
+        // Disposal uses the same local handler and releases no external process or desktop resource.
+        private static RemoteWebDriver NewRemoteDriver(WebDriverCommandInvoker invoker)
+        {
+            // Disable remote session allocation because the test controls the opaque session identifier.
+            var session = new SessionModel
+            {
+                StartNewSession = false
+            };
+
+            // Attach the invoker session to the driver before any UiaElement captures it.
+            return new RemoteWebDriver(invoker, session)
+            {
+                Session = invoker.Session
+            };
+        }
+
+        // Captures request endpoints in a thread-safe queue and returns a stable WebDriver response.
+        // The handler performs no network I/O and exposes snapshots so tests cannot mutate its owned request history.
+        private sealed class RecordingHttpMessageHandler : HttpMessageHandler
+        {
+            // Owns the request URI history shared by sequential and parallel command tests.
+            private readonly ConcurrentQueue<Uri> _requestUris = new();
+
+            // Returns a detached request snapshot so assertions observe completed requests without sharing mutable state.
+            internal Uri[] GetRequestUris()
+            {
+                return [.. _requestUris];
+            }
+
+            /// <inheritdoc />
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                // Capture the resolved endpoint before returning a successful protocol response.
+                _requestUris.Enqueue(request.RequestUri);
+
+                // Return a stable value that supports both focus and attribute response parsing.
+                var response = new HttpResponseMessage(statusCode: HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        content: "{\"value\":\"captured\"}",
+                        encoding: Encoding.UTF8,
+                        mediaType: "application/json"),
+                    RequestMessage = request
+                };
+
+                return Task.FromResult(result: response);
+            }
         }
     }
 }

--- a/src/G4.WebDriver/Extensions/PublicExtensions.cs
+++ b/src/G4.WebDriver/Extensions/PublicExtensions.cs
@@ -772,25 +772,25 @@ namespace G4.WebDriver.Extensions
         /// <exception cref="NotSupportedException">Thrown when the specified command is not supported.</exception>
         public static WebDriverCommandModel NewCommand(this IWebDriverCommandInvoker invoker, string commandName)
         {
-            // Check if the invoker is null
-            if (invoker == null)
+            // Require an invoker before reading its registered command templates.
+            ArgumentNullException.ThrowIfNull(
+                argument: invoker,
+                paramName: nameof(invoker));
+
+            // Reject an absent template before allocating invocation-owned command state.
+            if (string.IsNullOrEmpty(commandName) ||
+                !invoker.Commands.TryGetValue(commandName, out var template))
             {
-                throw new ArgumentNullException(nameof(invoker), "The invoker cannot be null.");
+                var message = $"The command '{commandName}' is not supported.";
+                throw new NotSupportedException(message);
             }
 
-            // Check if the command name is empty or not present in the invoker's commands
-            if (string.IsNullOrEmpty(commandName) || !invoker.Commands.TryGetValue(commandName, out WebDriverCommandModel value))
-            {
-                throw new NotSupportedException($"The command '{commandName}' is not supported.");
-            }
+            // Copy the registered template so route, payload, and element mutations remain local to this invocation.
+            var command = template.Copy();
 
-            // Get the command from the invoker's commands
-            var command = value;
-
-            // Set the session for the command, if a session is available
+            // Apply the active session only to the new command so the registered template remains reusable.
             command.Session = invoker.Session?.OpaqueKey;
 
-            // Return the created command
             return command;
         }
 

--- a/src/G4.WebDriver/Models/WebDriverCommandModel.cs
+++ b/src/G4.WebDriver/Models/WebDriverCommandModel.cs
@@ -8,6 +8,8 @@ namespace G4.WebDriver.Models
     /// </summary>
     public class WebDriverCommandModel
     {
+        #region *** Properties   ***
+
         /// <summary>
         /// Gets or sets the request content type. Default is "application/json";
         /// </summary>
@@ -42,5 +44,35 @@ namespace G4.WebDriver.Models
         /// Gets or sets the session id to use with the command.
         /// </summary>
         public string Session { get; set; }
+
+        #endregion
+
+        #region *** Methods      ***
+
+        /// <summary>
+        /// Copies this command into invocation-owned state so request-specific values cannot mutate a registered template.
+        /// </summary>
+        /// <returns>A new command containing the current definition and request values.</returns>
+        internal WebDriverCommandModel Copy()
+        {
+            // Duplicate caller-provided headers so one invocation cannot change another invocation's collection.
+            var headers = Headers == null
+                ? null
+                : new Dictionary<string, string>(Headers);
+
+            // Preserve every command value on a distinct model so later route and payload mutations remain isolated.
+            return new WebDriverCommandModel
+            {
+                ContentType = ContentType,
+                Data = Data,
+                Element = Element,
+                Headers = headers,
+                Method = Method,
+                Route = Route,
+                Session = Session
+            };
+        }
+
+        #endregion
     }
 }

--- a/src/G4.WebDriver/Remote/WebDriverCommandInvoker.cs
+++ b/src/G4.WebDriver/Remote/WebDriverCommandInvoker.cs
@@ -264,48 +264,35 @@ namespace G4.WebDriver.Remote
         /// Invokes a WebDriver command by name.
         /// </summary>
         /// <param name="commandName">The name of the WebDriver command to be invoked.</param>
-        /// <returns>The response model containing the result of the WebDriver command execution.</returns>
+        /// <returns>The response model containing the result of the command invoked without a request payload.</returns>
         public WebDriverResponseModel Invoke(string commandName)
         {
-            // Check if the command name is null or empty, or if the command is not found in the dictionary.
-            if (string.IsNullOrEmpty(commandName) || !Commands.TryGetValue(commandName, out WebDriverCommandModel commandOut))
-            {
-                throw new NotSupportedException($"The WebDriver command with the name '{commandName}' is not supported or not found.");
-            }
-
-            // Retrieve the WebDriver command from the dictionary.
-            var command = commandOut;
-
-            // Set the command data to null and set the session if available.
-            command.Data = null;
-            command.Session = Session?.OpaqueKey;
-
-            // Invoke the WebDriver command and return the command response model.
-            return Invoke(command);
+            // Route payload-free callers through the complete overload so command ownership has one implementation.
+            return Invoke(commandName, data: null);
         }
 
         /// <summary>
         /// Invokes a WebDriver command by name and with the specified data.
         /// </summary>
         /// <param name="commandName">The name of the WebDriver command to be invoked.</param>
-        /// <param name="data">The data to be associated with the command.</param>
+        /// <param name="data">The optional request payload assigned only to this command invocation.</param>
         /// <returns>The response model containing the result of the WebDriver command execution.</returns>
         public WebDriverResponseModel Invoke(string commandName, object data)
         {
-            // Check if the command name is null or empty, or if the command is not found in the dictionary.
-            if (string.IsNullOrEmpty(commandName) || !Commands.TryGetValue(commandName, out WebDriverCommandModel commandOut))
+            // Reject an unsupported command before allocating invocation-owned request state.
+            if (string.IsNullOrEmpty(commandName) || !Commands.TryGetValue(commandName, out var commandOut))
             {
-                throw new NotSupportedException($"The WebDriver command with the name '{commandName}' is not supported or not found.");
+                var message = $"The WebDriver command with the name '{commandName}' is not supported or not found.";
+                throw new NotSupportedException(message);
             }
 
-            // Retrieve the WebDriver command from the dictionary.
-            var command = commandOut;
+            // Copy the registered template so this invocation owns every mutable request value.
+            var command = commandOut.Copy();
 
-            // Set the command data and session.
+            // Apply the request-specific payload and session without changing the reusable template.
             command.Data = data;
             command.Session = Session?.OpaqueKey;
 
-            // Invoke the WebDriver command and return the command response model.
             return Invoke(command);
         }
 
@@ -346,41 +333,46 @@ namespace G4.WebDriver.Remote
         /// <returns>The response model containing the result of the WebDriver command execution.</returns>
         public WebDriverResponseModel Invoke(WebDriverCommandModel command)
         {
-            // Set the content type for the command to JSON
-            command.ContentType = "application/json";
+            // Require a command before allocating the isolated request sent to the remote endpoint.
+            ArgumentNullException.ThrowIfNull(
+                argument: command,
+                paramName: nameof(command));
 
-            // Replace placeholders in the command route with session and element values
-            command.Route = command
+            // Copy caller-owned state so route expansion and transport metadata never escape this invocation.
+            var invocation = command.Copy();
+            invocation.ContentType = "application/json";
+
+            // Resolve placeholders only on the invocation copy so registered templates remain reusable.
+            invocation.Route = invocation
                 .Route
-                .Replace("$[session]", command.Session)
-                .Replace("$[element]", command.Element);
+                .Replace("$[session]", invocation.Session)
+                .Replace("$[element]", invocation.Element);
 
-            // Get the server address and remove trailing slashes
+            // Normalize the server address once so event observers and transport use the same endpoint root.
             var serverAddress = ServerAddress.AbsoluteUri.Trim('/');
 
-            // Invoke the CommandInvoking event
-            CommandInvoking?.Invoke(sender: this, e: new(serverAddress, command));
+            // Publish the resolved invocation without exposing or mutating the registered command template.
+            CommandInvoking?.Invoke(sender: this, e: new(serverAddress, invocation));
 
-            // Send the command and get the response
-            var response = command.Send(_httpClient, baseUrl: serverAddress, _timeout, _keepAlive);
+            // Send the isolated request so concurrent invocations cannot exchange route, element, or payload state.
+            var response = invocation.Send(_httpClient, baseUrl: serverAddress, _timeout, _keepAlive);
 
-            // Invoke the CommandInvoked event
+            // Publish the completed transport response after the request lifecycle finishes.
             CommandInvoked?.Invoke(sender: this, e: new(serverAddress, response));
 
-            // Handle special case for 404 Not Found with no session (NoSuchSessionException)
-            if (response.StatusCode == HttpStatusCode.NotFound && string.IsNullOrEmpty(command.Session))
+            // Translate an anonymous 404 into the established missing-session failure contract.
+            if (response.StatusCode == HttpStatusCode.NotFound && string.IsNullOrEmpty(invocation.Session))
             {
                 var error404 = response.Content.ReadAsStringAsync().Result;
                 throw new NoSuchSessionException(error404);
             }
 
-            // Create a WebDriver response model from the HTTP response
+            // Convert the transport result before applying the shared WebDriver error mapping.
             var webDriverResponse = WebDriverResponseModel.New(response);
 
-            // Assert the WebDriver response
+            // Enforce protocol errors before returning the successful response to the caller.
             AssertWebDriverResponse(webDriverResponse);
 
-            // Return the WebDriver response model
             return webDriverResponse;
         }
 

--- a/src/G4.sln
+++ b/src/G4.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.12.35707.178
+# Visual Studio Version 18
+VisualStudioVersion = 18.8.12021.73 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "G4.WebDriver", "G4.WebDriver\G4.WebDriver.csproj", "{3821BE27-7D3B-4508-BAF4-00389A8EA017}"
 EndProject
@@ -60,7 +60,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".test", ".test", "{42501EC6-B315-4EFA-A3C2-F179DA47ECF7}"
 	ProjectSection(SolutionItems) = preProject
 		..\test\settings\Default.runsettings = ..\test\settings\Default.runsettings
-		..\test\settings\Local.runsettings = ..\test\settings\Local.runsettings
 	EndProjectSection
 EndProject
 Global
@@ -124,5 +123,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B9B32C4C-DA4D-4AA7-A42A-6712F1BC5B74}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Refactor command creation to ensure each WebDriver command invocation uses an independent copy of the command template, preventing shared mutable state. Introduce Copy() on WebDriverCommandModel and update extension methods and invoker logic. Replace direct Commands[] access with NewCommand(). Add unit tests to verify template immutability and correct parallel/sequential behavior. Add RecordingHttpMessageHandler for test assertions. Update solution files for newer Visual Studio and remove obsolete test settings.